### PR TITLE
fix/variables-naming

### DIFF
--- a/playbooks/daily-scan.yaml
+++ b/playbooks/daily-scan.yaml
@@ -97,7 +97,7 @@
         curl -X POST "{{ pipeline_conf.dojo_url }}"
         -H "Authorization: Token {{ pipeline_conf.dojo_api_key }}"
         -F "file=@scan_results/nuclei-results.json"
-        -F "engagement={{ pipeline_conf.engagement_id }}"
+        -F "engagement={{ pipeline_conf.daily_scan_engagement_id }}"
         -F "scan_type={{ scan_type }}"
         -F "verified=true"
         -F "active=true"


### PR DESCRIPTION
Fix typo on playbook variable naming ("engagement_id" -> "daily_scan_engagement_id")