### PR TITLE
Start job rework to allow testing of the job itself

### DIFF
--- a/.zuul.d/config.yaml
+++ b/.zuul.d/config.yaml
@@ -3,47 +3,137 @@
     name: SovereignCloudStack/security-infra-scan-pipeline
     default-branch: main
     merge-mode: "squash-merge"
-    periodic-daily:
-      jobs:
-        - scs-daily-security-scan
-    periodic-weekly:
-      jobs:
-        - scs-weekly-security-scan
-    post:
-      jobs:
-        - noop
     check:
       jobs:
-        - noop
+        - scs-baseline-security-scan-test
+        - scs-full-security-scan-test
+        - scs-greenbone-security-scan-test
+    gate:
+      jobs:
+        - scs-baseline-security-scan-test
+        - scs-full-security-scan-test
+        - scs-greenbone-security-scan-test
+    periodic-daily:
+      jobs:
+        - scs-baseline-security-scan
+    periodic-weekly:
+      jobs:
+        - scs-full-security-scan
+        - scs-greenbone-security-scan
 
 - job:
-    name: scs-daily-security-scan
+    name: scs-security-scan-base
     parent: base
-    timeout: 7200 #2h
+    description: |
+      Base for any security scanning job
+    timeout: 3600 #1h
+    pre-run: playbooks/pre.yaml
+    post-run: playbooks/post.yaml
+    vars:
+      # Where to store intermediate data
+      scan_work_dir: "{{ ansible_user_dir }}/wrk"
+      # Where to flush (and read) results from
+      scan_results_dir: "{{ ansible_user_dir }}/wrk/scan_results"
+      # Default list of scan targets.
+      # NOTE(gtema): It would be nice in tests to use test instance itself, but
+      # it only exposes SSH port what makes scanning very fast and reports
+      # empty. We potentially want to see how the reports are looking like also 
+      # in tests.
+      scan_targets:
+        - 213.131.230.161
+
+- job:
+    name: scs-baseline-security-scan-base
+    parent: scs-security-scan-base
+    description: |
+      Base for the security scan involving naabu/nuclei/httpx/OWASP Zap.
+
+      OWASP Zap test is performed in the baseline configuration
+    run: playbooks/daily-scan.yaml
+    vars:
+      zap_script: "zap-baseline.py"
+
+- job:
+    name: scs-baseline-security-scan
+    parent: scs-baseline-security-scan-base
+    description: |
+      Perform baseline scan of the resources
     secrets:
      - name: pipeline_conf
        secret: SECRET_SECURITY_INFRA_SCAN_PIPELINE
-    pre-run: playbooks/pre.yaml
-    run: playbooks/daily-scan.yaml
     vars:
       # TODO: engagement_id is not a secret, define id here directly
       # Since in Zuul it is not possible to define vars from secrets on the
       # job level pass a key name down to the job
       engagement: "daily_scan_engagement_id"
-      zap_script: "zap-baseline.py"
 
 - job:
-    name: scs-weekly-security-scan
-    parent: base
-    timeout: 21600 #6h
+    name: scs-baseline-security-scan-test
+    parent: scs-baseline-security-scan-base
+    description: |
+      Test baseline-security-scan job on the test resources.
+
+      Since this is an untrusted job it does not have access to the secrets
+      and thus not posting results to the DefectDojo.
+    vars:
+      pipeline_conf:
+        dojo_url: https://demo.defectdojo.com/api/v2/import-scan/
+        daily_scan_engagement_id: 1
+        weekly_scan_engagement_id: 1
+        dojo_auth: "Basic YWRtaW46MURlZmVjdGRvam9AZGVtbyNhcHBzZWM="
+
+- job:
+    name: scs-full-security-scan-base
+    parent: scs-security-scan-base
+    description: |
+      Base for the security scan involving naabu/nuclei/httpx/OWASP Zap.
+
+      OWASP Zap test is performed in the full configuration
+    run: playbooks/daily-scan.yaml
+    vars:
+      zap_script: "zap-full-scan.py"
+
+- job:
+    name: scs-full-security-scan-test
+    parent: scs-full-security-scan-base
+    description: |
+      Test full-security-scan job on the test resources.
+
+      Since this is an untrusted job it does not have access to the secrets
+      and thus not posting results to the DefectDojo.
+
+- job:
+    name: scs-full-security-scan
+    parent: scs-full-security-scan-base
     secrets:
      - name: pipeline_conf
        secret: SECRET_SECURITY_INFRA_SCAN_PIPELINE
-    pre-run: playbooks/pre.yaml
-    run: playbooks/weekly-scan.yaml
     vars:
       # TODO: engagement_id is not a secret, define id here directly
       # Since in Zuul it is not possible to define vars from secrets on the
       # job level pass a key name down to the job
       engagement: "weekly_scan_engagement_id"
-      zap_script: "zap-full-scan.py"
+
+- job:
+    name: scs-greenbone-security-scan-base
+    parent: scs-security-scan-base
+    description: |
+      Perform baseline scan of the resources
+    timeout: 21600 #6h
+    run: playbooks/greenbone.yaml
+
+- job:
+    name: scs-greenbone-security-scan
+    parent: scs-greenbone-security-scan-base
+    secrets:
+     - name: pipeline_conf
+       secret: SECRET_SECURITY_INFRA_SCAN_PIPELINE
+    vars:
+      # TODO: engagement_id is not a secret, define id here directly
+      # Since in Zuul it is not possible to define vars from secrets on the
+      # job level pass a key name down to the job
+      engagement: "weekly_scan_engagement_id"
+
+- job:
+    name: scs-greenbone-security-scan-test
+    parent: scs-greenbone-security-scan-base

--- a/playbooks/greenbone.yaml
+++ b/playbooks/greenbone.yaml
@@ -6,11 +6,11 @@
     - name: Start Greenbone containers
       become: true
       ansible.builtin.shell: |
-        docker-compose -f greenbone-compose.yaml -p greenbone-community-edition up -d
+        docker-compose -f {{ scan_work_dir }}/greenbone-compose.yaml -p greenbone-community-edition up -d
 
     # https://greenbone.github.io/docs/latest/22.4/container/workflows.html#exposing-gvmd-unix-socket-for-gmp-access
     - name: Wait until gvmd socket is present before continuing (/tmp/gvm/gvmd/gvmd.sock)
-      wait_for:
+      ansible.builtin.wait_for:
         path: /tmp/gvm/gvmd/gvmd.sock
         state: present
 
@@ -21,24 +21,44 @@
       until: "'<currently_syncing>' not in feed_status.stdout"
       retries: 60
       delay: 60
-      ignore_errors: yes
+      changed_when: false
 
     - name: Execute the GVM scan script
       ansible.builtin.shell: |
-        python3 ~/gvm_scan.py
+        python3 {{ scan_work_dir }}/gvm_scan.py --reports-dir {{ scan_results_dir }}/gvm_reports {{ ['--target'] | product(scan_targets) | map('join', ' ') | join(' ') }}
       register: scan_result
-      ignore_errors: yes
 
-    - name: Upload results to DefecDojo
-      ansible.builtin.shell: |
-        # Upload each XML report to Defect Dojo
-        for filename in $(ls {{ reports_dir }}/*.xml); do
-            echo "Uploading $filename to Defect Dojo"
-            curl -X POST "{{ pipeline_conf.dojo_url }}" -H "Authorization: Token {{ pipeline_conf.dojo_api_key }}" -F "file=@${filename}" -F "engagement={{ pipeline_conf[engagement] }}" -F "scan_type={{ scan_type }}" -F "verified=true" -F "skip_duplicates=false" -F "close_old_findings=true"
-        done
-      args:
-        executable: /bin/bash
-      vars:
-        scan_type: OpenVAS Parser
-        reports_dir: "/home/ubuntu/scan_results/gvm_reports"
-      ignore_errors: true
+    - name: Find Greenbone reports
+      ansible.builtin.find:
+        paths: "{{ scan_results_dir }}/gvm_reports"
+        patterns: "*.xml"
+      register: "gvm_reports"
+
+    - name: Read in Greenbone reports content
+      ansible.builtin.slurp:
+        src: "{{ item.path }}"
+      loop: "{{ gvm_reports.files }}"
+      register: "gvm_reports_content"
+
+    - name: Send Greenbone results to Defect Dojo
+      no_log: true
+      ansible.builtin.uri:
+        url: "{{ pipeline_conf.dojo_url }}"
+        headers:
+          Authorization: "{{ ('Token ' + pipeline_conf.dojo_api_key) if pipeline_conf.dojo_api_key is defined else pipeline_conf.dojo_auth }}"
+        method: "POST"
+        body_format: "form-multipart"
+        body:
+          engagement: "{{ pipeline_conf[engagement] }}"
+          scan_type: "OpenVAS Parser"
+          verified: "true"
+          active: "true"
+          skip_duplicates: "false"
+          close_old_findings: "true"
+          file: "{{ zj_item['content'] | b64decode }}"
+      loop: "{{ gvm_reports_content.results }}"
+      loop_control:
+        loop_var: zj_item
+      when:
+        - "engagement is defined and engagement"
+        - "pipeline_conf is defined"

--- a/playbooks/httpx.yaml
+++ b/playbooks/httpx.yaml
@@ -2,23 +2,15 @@
 - name: Perform Scan with httpx
   hosts: all
   tasks:
+    # Invoke httpx container waiting for the container to complete
     - name: Run httpx scan
       community.docker.docker_container:
         name: httpx_scan
         image: "projectdiscovery/httpx"
         command: "-l /tmp/scan_results/naabu-results.txt -o /tmp/scan_results/httpx-results.txt"
         volumes:
-          - "~/:/tmp"
-        state: started
-        detach: true
+          - "{{ scan_work_dir }}:/tmp"
+        state: "started"
+        detach: false
         auto_remove: true
       register: httpx_container_result
-
-    - name: Wait for httpx container to complete successfully
-      community.docker.docker_container_info:
-        name: httpx_scan
-      register: httpx_container_info
-      until: httpx_container_info.container.State.Running == false and httpx_container_info.container.State.ExitCode == 0
-      retries: 120
-      delay: 1
-      ignore_errors: true

--- a/playbooks/naabu.yaml
+++ b/playbooks/naabu.yaml
@@ -3,23 +3,15 @@
   hosts: all
   tasks:
 
+    # Invoke naabu container waiting for the container to complete
     - name: Run naabu scan
       community.docker.docker_container:
         name: naabu_scan
         image: "projectdiscovery/naabu"
-        command: "-list /tmp/targets.txt -o /tmp/scan_results/naabu-results.txt"
-        volumes:
-          - "~/:/tmp"
-        state: started
-        detach: true
+        command: "-host {{ scan_targets | default([ansible_ssh_host]) | list | join(',') }} -o /tmp/scan_results/naabu-results.txt"
+        state: "started"
+        detach: false
         auto_remove: true
+        volumes:
+          - "{{ scan_work_dir }}:/tmp"
       register: naabu_container_result
-
-    - name: Wait for naabu container to complete successfully
-      community.docker.docker_container_info:
-        name: naabu_scan
-      register: naabu_container_info
-      until: naabu_container_info.container.State.Running == false and naabu_container_info.container.State.ExitCode == 0
-      retries: 120
-      delay: 1
-      ignore_errors: true

--- a/playbooks/nuclei.yaml
+++ b/playbooks/nuclei.yaml
@@ -3,38 +3,50 @@
   hosts: all
   tasks:
 
+    # Invoke nuclei container waiting for the container to complete
     - name: Run nuclei scan
       community.docker.docker_container:
         name: nuclei_scan
         image: "projectdiscovery/nuclei"
         command: "-list /tmp/scan_results/httpx-results.txt -j -o /tmp/scan_results/nuclei-results.json"
         volumes:
-          - "~/:/tmp"
-        state: started
-        detach: true
+          - "{{ scan_work_dir }}:/tmp"
+        state: "started"
+        detach: false
         auto_remove: true
       register: nuclei_container_result
 
-    # As nuclei takes an indeterminate amount of time, check for container status each 30 seconds in a 90 minutes frame
-    - name: Wait for nuclei container to complete successfully
-      community.docker.docker_container_info:
-        name: nuclei_scan
-      register: nuclei_container_info
-      until: nuclei_container_info.container.State.Running == false and nuclei_container_info.container.State.ExitCode == 0
-      retries: 540
-      delay: 30
-      ignore_errors: true
+    - name: Find Nuclei report
+      ansible.builtin.find:
+        paths: "{{ scan_results_dir }}"
+        patterns: "nuclei-results.json"
+      register: "nuclei_reports"
 
-    - name: Send nuclei results to Defect Dojo
-      vars:
-        scan_type: Nuclei Scan
-      command: >
-        curl -X POST "{{ pipeline_conf.dojo_url }}"
-        -H "Authorization: Token {{ pipeline_conf.dojo_api_key }}"
-        -F "file=@scan_results/nuclei-results.json"
-        -F "engagement={{ pipeline_conf[engagement] }}"
-        -F "scan_type={{ scan_type }}"
-        -F "verified=true"
-        -F "active=true"
-        -F "skip_duplicates=false"
-        -F "close_old_findings=true"
+    - name: Read in Nuclei report content
+      ansible.builtin.slurp:
+        src: "{{ item.path }}"
+      loop: "{{ nuclei_reports.files }}"
+      register: "nuclei_reports_content"
+
+    - name: Send Nuclei results to Defect Dojo
+      no_log: true
+      ansible.builtin.uri:
+        url: "{{ pipeline_conf.dojo_url }}"
+        headers:
+          Authorization: "{{ ('Token ' + pipeline_conf.dojo_api_key) if pipeline_conf.dojo_api_key is defined else pipeline_conf.dojo_auth }}"
+        method: "POST"
+        body_format: "form-multipart"
+        body:
+          engagement: "{{ pipeline_conf[engagement] }}"
+          scan_type: "Nuclei Scan"
+          verified: "true"
+          active: "true"
+          skip_duplicates: "false"
+          close_old_findings: "true"
+          file: "{{ zj_item['content'] | b64decode }}"
+      loop: "{{ nuclei_reports_content.results }}"
+      loop_control:
+        loop_var: zj_item
+      when:
+        - "engagement is defined and engagement"
+        - "pipeline_conf is defined"

--- a/playbooks/owasp-zap.yaml
+++ b/playbooks/owasp-zap.yaml
@@ -2,32 +2,60 @@
   hosts: all
   tasks:
 
-    - name: Run OWASP Zap scan
-      ansible.builtin.shell: |
-        # Function to run ZAP baseline scan
-        run_zap_scan() {
-            local target=$1
-            echo "Scanning target: $target"
-            docker run --rm -v {{ reports_dir }}:/zap/wrk/:rw --user root -t ghcr.io/zaproxy/zaproxy:stable {{ zap_script }} -t $target -x $(echo $target | sed 's/[^a-zA-Z0-9]/_/g').xml
-        }
+    - name: Fetch httpx data
+      ansible.builtin.slurp:
+        src: "{{ scan_results_dir }}/httpx-results.txt"
+      register: httpx_results
 
-        # Read targets and run scans
-        while IFS= read -r target
-        do
-            run_zap_scan $target
-        done < "{{ targets_file }}"
+    - name: Run zap scan
+      community.docker.docker_container:
+        name: "zap"
+        image: "ghcr.io/zaproxy/zaproxy:stable"
+        command: "{{ zap_script }} -t {{ zj_item }} -x {{ zj_item | regex_replace('[^a-zA-Z0-9]', '_') }}.xml"
+        state: "started"
+        detach: false
+        volumes:
+          - "{{ scan_results_dir }}/zap_reports:/zap/wrk:rw"
+      register: zap
+      failed_when: "zap.status == 3"
+      loop: "{{ httpx_results['content'] | b64decode | split('\n') }}"
+      loop_control:
+        loop_var: zj_item
+      when:
+        - "zj_item != ''"
 
-        # Upload each XML report to Defect Dojo
-        for filename in $(ls {{ reports_dir }}/*.xml); do
-            echo "Uploading $filename to Defect Dojo"
-            curl -X POST "{{ pipeline_conf.dojo_url }}" -H "Authorization: Token {{ pipeline_conf.dojo_api_key }}" -F "file=@${filename}" -F "engagement={{ pipeline_conf[engagement] }}" -F "scan_type={{ scan_type }}" -F "verified=true" -F "skip_duplicates=false" -F "close_old_findings=true"
-        done
-      args:
-        executable: /bin/bash
-      environment:
-        PATH: "{{ ansible_env.PATH }}:/usr/local/bin"  # Ensure docker and python are in the path
-      vars:
-        scan_type: ZAP Scan
-        targets_file: "/home/ubuntu/scan_results/httpx-results.txt"
-        reports_dir: "/home/ubuntu/scan_results/zap_reports"
-      ignore_errors: true
+    - name: Find Zap reports
+      ansible.builtin.find:
+        paths: "{{ scan_results_dir }}/zap_reports"
+        patterns: "*.xml"
+      register: "zap_reports"
+
+    - name: Read in ZAP reports content
+      ansible.builtin.slurp:
+        src: "{{ item.path }}"
+      loop: "{{ zap_reports.files }}"
+      register: "zap_reports_content"
+
+    - name: Send Zap results to Defect Dojo
+      #  no_log: true
+      ansible.builtin.uri:
+        url: "{{ pipeline_conf.dojo_url }}"
+        headers:
+          Authorization: "{{ ('Token ' + pipeline_conf.dojo_api_key) if pipeline_conf.dojo_api_key is defined else pipeline_conf.dojo_auth }}"
+        method: "POST"
+        body_format: "form-multipart"
+        body:
+          engagement: "{{ pipeline_conf[engagement] }}"
+          scan_type: "ZAP Scan"
+          verified: "true"
+          active: "true"
+          skip_duplicates: "false"
+          close_old_findings: "true"
+          file: 
+            content: "{{ zj_item['content'] | b64decode }}"
+      loop: "{{ zap_reports_content.results }}"
+      loop_control:
+        loop_var: zj_item
+      when:
+        - "engagement is defined and engagement"
+        - "pipeline_conf is defined"

--- a/playbooks/post.yaml
+++ b/playbooks/post.yaml
@@ -1,0 +1,14 @@
+---
+- name: Fetch scan reports to be part of Zuul job logs
+  hosts: all
+  vars:
+    log_path: "{{ zuul.executor.log_root }}"
+  tasks:
+    - name: Fetch scan reports as Zuul logs
+      ansible.builtin.synchronize:
+        dest: "{{ log_path }}"
+        mode: pull
+        src: "{{ scan_results_dir }}"
+        verify_host: true
+        owner: no
+        group: no

--- a/playbooks/pre.yaml
+++ b/playbooks/pre.yaml
@@ -11,42 +11,41 @@
       ansible.builtin.pip:
         name:
         - "docker"
+
     - name: Install python-gvm library (Greenbone)
       ansible.builtin.pip:
         name:
         - "python-gvm"
         state: present
+
     - name: Install gvm-tools (Greenbone)
       become: true
       ansible.builtin.pip:
         name: 
         - "gvm-tools"
         state: present
+
     - name: Check if docker is installed
       command: docker --version
       register: docker_installed
       ignore_errors: true
+
     - name: Copy Files on the node
       ansible.builtin.copy:
         src: "../files/"
-        dest: "~/"
+        dest: "{{ scan_work_dir }}"
         mode: 0500
       no_log: false
-    - name: Check if scans output directory exists
+
+    - name: Ensure scan output directory exists
       ansible.builtin.file:
-        path: "~/scan_results"
+        path: "{{ item }}"
         state: directory
         mode: '0755'
-    - name: Check if zap scans output directory exists
-      ansible.builtin.file:
-        path: "~/scan_results/zap_reports"
-        state: directory
-        mode: '0755'
-    - name: Check if Greenbone scans output directory exists
-      ansible.builtin.file:
-        path: "~/scan_results/gvm_reports"
-        state: directory
-        mode: '0755'
+      loop:
+        - "{{ scan_results_dir }}/zap_reports"
+        - "{{ scan_results_dir }}/gvm_reports"
+
     - name: Check if greenbone folder for socket bind mount exists
       ansible.builtin.file:
         path: "/tmp/gvm/gvmd"

--- a/playbooks/weekly-scan.yaml
+++ b/playbooks/weekly-scan.yaml
@@ -1,5 +1,18 @@
 ---
 # individual scans are sharing data with each other using mounted volume, so the order matters
+
+# Greenbone takes quite some time to start. We can kick it and no other tasks in the meanwhile
+- name: Start Greenbone
+  hosts: all
+  tasks:
+
+     # TODO: replace with docker_compose_v2 once Zuul is
+# updated to 10.X so that community.docker collection is at least 3.6
+    - name: Start Greenbone containers
+      become: true
+      ansible.builtin.shell: |
+        docker-compose -f {{ scan_work_dir }}/greenbone-compose.yaml -p greenbone-community-edition up -d
+
 - name: Invoke Naabu scan
   ansible.builtin.import_playbook: naabu.yaml
 


### PR DESCRIPTION
A best practice of creating CI/CD jobs is to have a test for the job itself. That normally includes job execution with some stubs and fake inventory.
 
As an untrusted job it is not having access to the secrets (i.e. DefectDojo creds) so we are not able to test every single job step, but testing all the other parts is going to be very helpful.

Introduction of tests require improving parameterization of individual steps, which in turn uncovers more commonalities between steps. This allows splitting greenbone test out into a separate job while other tests are places in a separate jobs with either "zap-baseline" or "zap-full-scan" which are placed into the pipelines correspondingly.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
