### PR TITLE
pass-to-parent zuul secrets

### DIFF
--- a/.zuul.d/config.yaml
+++ b/.zuul.d/config.yaml
@@ -81,6 +81,7 @@
     secrets:
      - name: pipeline_conf
        secret: SECRET_SECURITY_INFRA_SCAN_PIPELINE
+       pass-to-parent: true
     vars:
       # TODO: engagement_id is not a secret, define id here directly
       # Since in Zuul it is not possible to define vars from secrets on the
@@ -140,6 +141,7 @@
     secrets:
      - name: pipeline_conf
        secret: SECRET_SECURITY_INFRA_SCAN_PIPELINE
+       pass-to-parent: true
     vars:
       # TODO: engagement_id is not a secret, define id here directly
       # Since in Zuul it is not possible to define vars from secrets on the
@@ -161,6 +163,7 @@
     secrets:
      - name: pipeline_conf
        secret: SECRET_SECURITY_INFRA_SCAN_PIPELINE
+       pass-to-parent: true
     vars:
       # TODO: engagement_id is not a secret, define id here directly
       # Since in Zuul it is not possible to define vars from secrets on the


### PR DESCRIPTION
When jobs are inherited Zuul does not pass secrets to the parent job
unless explicitly requested. This leads at the moment to absence of
secrets in the jobs trying to upload results to the defectdojo.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
