### PR TITLE
Make the dojo_url basepath

### DIFF
--- a/.zuul.d/config.yaml
+++ b/.zuul.d/config.yaml
@@ -102,7 +102,7 @@
         - zuul.sovereignit.cloud
 
       pipeline_conf:
-        dojo_url: https://demo.defectdojo.com/api/v2/import-scan/
+        dojo_url: https://demo.defectdojo.com
         daily_scan_engagement_id: 1
         weekly_scan_engagement_id: 1
         dojo_auth: "Basic YWRtaW46MURlZmVjdGRvam9AZGVtbyNhcHBzZWM="

--- a/playbooks/greenbone.yaml
+++ b/playbooks/greenbone.yaml
@@ -55,7 +55,7 @@
     - name: Send Greenbone results to Defect Dojo
       no_log: true
       ansible.builtin.uri:
-        url: "{{ pipeline_conf.dojo_url }}"
+        url: "{{ pipeline_conf.dojo_url }}/api/v2/import-scan"
         headers:
           Authorization: "{{ ('Token ' + pipeline_conf.dojo_api_key) if pipeline_conf.dojo_api_key is defined else pipeline_conf.dojo_auth }}"
         method: "POST"

--- a/playbooks/nuclei.yaml
+++ b/playbooks/nuclei.yaml
@@ -36,7 +36,7 @@
     - name: Send Nuclei results to Defect Dojo
       #no_log: true
       ansible.builtin.uri:
-        url: "{{ pipeline_conf.dojo_url }}"
+        url: "{{ pipeline_conf.dojo_url }}/api/v2/import-scan"
         headers:
           Authorization: "{{ ('Token ' + pipeline_conf.dojo_api_key) if pipeline_conf.dojo_api_key is defined else pipeline_conf.dojo_auth }}"
         method: "POST"

--- a/playbooks/owasp-zap.yaml
+++ b/playbooks/owasp-zap.yaml
@@ -52,7 +52,7 @@
     - name: Send Zap results to Defect Dojo
       #  no_log: true
       ansible.builtin.uri:
-        url: "{{ pipeline_conf.dojo_url }}"
+        url: "{{ pipeline_conf.dojo_url }}/api/v2/import-scan"
         headers:
           Authorization: "{{ ('Token ' + pipeline_conf.dojo_api_key) if pipeline_conf.dojo_api_key is defined else pipeline_conf.dojo_auth }}"
         method: "POST"


### PR DESCRIPTION
in tests dojo_url is a full api path while in secrets we have only a
base url. Ensure all tasks explicitly construct required url.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
